### PR TITLE
chore: Fix plugin-import

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6,7 +6,6 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const basic_json_1 = __importDefault(require("./rules/basic.json"));
 const etc_json_1 = __importDefault(require("./rules/etc.json"));
 const functional_json_1 = __importDefault(require("./rules/functional.json"));
-const import_json_1 = __importDefault(require("./rules/import.json"));
 const jsx_a11y_json_1 = __importDefault(require("./rules/jsx-a11y.json"));
 const node_json_1 = __importDefault(require("./rules/node.json"));
 const react_json_1 = __importDefault(require("./rules/react.json"));
@@ -39,6 +38,7 @@ module.exports = {
         'plugin:etc/recommended',
         'plugin:@microsoft/sdl/recommended',
         'plugin:react-hooks/recommended',
+        'plugin:import/typescript',
     ],
     plugins: [
         'no-autofix',
@@ -64,11 +64,8 @@ module.exports = {
         tsconfigRootDir: './',
         sourceType: 'module'
     },
-    rules: Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, basic_json_1.default), etc_json_1.default), functional_json_1.default), import_json_1.default), jsx_a11y_json_1.default), node_json_1.default), shopify_json_1.default), react_json_1.default), security_json_1.default), simple_import_sort_json_1.default), sonarjs_json_1.default), typescript_json_1.default), unicorn_json_1.default), react_hooks_json_1.default),
+    rules: Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, basic_json_1.default), etc_json_1.default), functional_json_1.default), jsx_a11y_json_1.default), node_json_1.default), shopify_json_1.default), react_json_1.default), security_json_1.default), simple_import_sort_json_1.default), sonarjs_json_1.default), typescript_json_1.default), unicorn_json_1.default), react_hooks_json_1.default),
     settings: {
-        'import/resolver': {
-            typescript: {}
-        },
         react: {
             version: 'detect'
         }

--- a/dist/rules/import.json
+++ b/dist/rules/import.json
@@ -1,6 +1,0 @@
-{
-    "import/named": "error",
-    "import/no-cycle": ["error", {
-            "maxDepth": "∞"
-        }]
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import basicRules from './rules/basic.json';
 import etcRules from './rules/etc.json';
 import functionalRules from './rules/functional.json';
-import importRules from './rules/import.json';
 import jsxA11yRules from './rules/jsx-a11y.json';
 import nodeRules from './rules/node.json';
 import reactRules from './rules/react.json';
@@ -35,6 +34,7 @@ module.exports = {
     'plugin:etc/recommended',
     'plugin:@microsoft/sdl/recommended',
     'plugin:react-hooks/recommended',
+    'plugin:import/typescript',
   ],
   plugins: [
     'no-autofix',
@@ -64,7 +64,6 @@ module.exports = {
     ...basicRules,
     ...etcRules,
     ...functionalRules,
-    ...importRules,
     ...jsxA11yRules,
     ...nodeRules,
     ...shopitfyRules,
@@ -77,9 +76,6 @@ module.exports = {
     ...reactHooks,
   },
   settings: {
-    'import/resolver': {
-      typescript: {}
-    },
     react: {
       version: 'detect'
     }

--- a/src/rules/import.json
+++ b/src/rules/import.json
@@ -1,6 +1,0 @@
-{
-  "import/named": "error",
-  "import/no-cycle": ["error", {
-    "maxDepth": "∞"
-  }]
-}


### PR DESCRIPTION
Apparently `plugin-import` has never worked before (not sure why). After update, it started working which caused some errors. Here, I get rid of our rules since they didn't work before and `import/named` rule is meant for js, not ts: https://github.com/import-js/eslint-plugin-import/blob/main/config/typescript.js#L25-L30

If we want to enable `no-cycle` rule, it must be done later because showroom has cycled imports